### PR TITLE
feat: works in browser

### DIFF
--- a/__tests__/entity.js
+++ b/__tests__/entity.js
@@ -1,4 +1,4 @@
-import Entity from '../src/entity'
+import { Entity } from '../src/entity'
 
 class TestEntity extends Entity {
   constructor (snapshot, events) {
@@ -71,7 +71,7 @@ describe('entity', function () {
   })
   describe('#enqueue', function () {
     it('should enqueue EventEmitter style events by adding them to array of events to emit', function () {
-      var test = new TestEntity()
+      const test = new TestEntity()
 
       test.enqueue('something.happened', { data: 'data' }, { data2: 'data2' })
 
@@ -86,12 +86,12 @@ describe('entity', function () {
   })
   describe('#merge', function () {
     it('should merge a snapshot into the current snapshot, overwriting any common properties', function () {
-      var snapshot = {
+      const snapshot = {
         property: true,
         property2: true
       }
 
-      var test = new TestEntity()
+      const test = new TestEntity()
 
       test.merge(snapshot)
 
@@ -99,11 +99,11 @@ describe('entity', function () {
       expect(test.property2).toEqual(true)
     })
     it('should merge a complex snapshot (missing newly added fields) while maintaining defaulted sub-object values', function () {
-      var snapshot = {
+      const snapshot = {
         property: true
       }
 
-      var test = new TestEntity()
+      const test = new TestEntity()
 
       test.merge(snapshot)
 
@@ -114,7 +114,7 @@ describe('entity', function () {
       expect(test.property2.subProperty2).toEqual(true)
     })
     it('should merge a complex snapshot while maintaining defaulted sub-object values', function () {
-      var snapshot = {
+      const snapshot = {
         property: true,
         property2: {
           subProperty: true,
@@ -122,7 +122,7 @@ describe('entity', function () {
         }
       }
 
-      var test = new TestEntity()
+      const test = new TestEntity()
 
       test.merge(snapshot)
 
@@ -135,28 +135,28 @@ describe('entity', function () {
   })
   describe('#replay', function () {
     it('should throw an entity error with name of model when attempting to replay a method an entity does not implement', function () {
-      var events = [
+      const events = [
         {
           method: 'someMethod',
           data: { some: 'param' }
         }
       ]
 
-      var test = new TestEntity()
+      const test = new TestEntity()
 
       expect(function () {
         test.replay(events)
       }).toThrow('method \'someMethod\' does not exist on model \'TestEntity\'')
     })
     it('should not emit events during replay', function () {
-      var events = [
+      const events = [
         {
           method: 'method',
           data: { some: 'param' }
         }
       ]
 
-      var test = new TestEntity()
+      const test = new TestEntity()
 
       test.on('method-ed', function () {
         throw new Error('should not emit during replay')
@@ -172,7 +172,7 @@ describe('entity', function () {
 
       test.method(data)
 
-      var snapshot = test.snapshot()
+      const snapshot = test.snapshot()
 
       expect(snapshot.property2).toEqual(data.data)
       expect(snapshot.snapshotVersion).toEqual(1)

--- a/__tests__/entityProxy.js
+++ b/__tests__/entityProxy.js
@@ -1,4 +1,4 @@
-import Entity from '../src/entityProxy'
+import { EntityProxy as Entity } from '../src/entityProxy'
 import util from 'util'
 
 function User () {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,15 +1,13 @@
 import {
   Entity,
   Value,
-  SourcedEntity,
-  SourcedValue
+  EntityProxy
 } from '../src/index'
 
 describe('index', () => {
-  it('exports Entity, Value, SourcedEntity, SourcedValue', () => {
+  it('exports Entity, Value, EntityProxy', () => {
     expect(Entity).toBeDefined()
     expect(Value).toBeDefined()
-    expect(SourcedEntity).toBeDefined()
-    expect(SourcedValue).toBeDefined()
+    expect(EntityProxy).toBeDefined()
   })
 })

--- a/__tests__/value.js
+++ b/__tests__/value.js
@@ -1,4 +1,4 @@
-import Value from '../src/value'
+import { Value } from '../src/value'
 
 describe('value', function () {
   it('should be immutable', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "debug": "4.3.2",
+        "eventemitter3": "4.0.7",
         "lodash.clonedeep": "4.5.0",
         "lodash.merge": "4.6.2"
       },
@@ -5723,6 +5724,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -20477,6 +20483,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "debug": "4.3.2",
+    "eventemitter3": "4.0.7",
     "lodash.clonedeep": "4.5.0",
     "lodash.merge": "4.6.2"
   }

--- a/src/entityProxy.js
+++ b/src/entityProxy.js
@@ -1,13 +1,10 @@
-import SourcedEntity from './entity'
+import { Entity } from './entity'
 import debug from 'debug'
 
 const log = debug('sourced')
 
-let hasWarned = false
-
 const proxyConstructor = {
   apply: (Target, thisArg, args) => {
-    if (!hasWarned) warnUser()
     log(`Initializing ${Target.name} with:`, args)
     const entity = new Target()
     Object.assign(thisArg, entity)
@@ -15,30 +12,4 @@ const proxyConstructor = {
   }
 }
 
-const warnUser = () => {
-  console.warn(`DEPRECATION WARNING:
-Thanks for using sourced! We've recently upgraded our internal APIs to make use of ECMAScript (ES6+) style classes.
-
-You are currently using a proxied version of the new "SourcedEntity" class.
-
-We made this so you don't have to do anything right now, however, in a future version, the current "Entity" 
-which is a Proxy, that you are using now, will be renamed to EntityProxy in order to free up the "Entity" class name.
-
-At that point you will have to change your require statement to 
-
-    var Entity = require('sourced').EntityProxy;
-
-in order to continue using the classic prototypical inheritance approach, or refactor to use classes.
-
-An example of using Sourced with Classes is available here:
-
-https://github.com/patrickleet/sourced-repo-mongo/blob/cb8c40084d0fcf6f8aa8524ef5d6c03518eb9d47/index.test.js#L10
-
-The key difference is calling "rehydrate" at the end of your constructor.
-    `)
-  hasWarned = true
-}
-
-const Entity = new Proxy(SourcedEntity, proxyConstructor)
-
-export default Entity
+export const EntityProxy = new Proxy(Entity, proxyConstructor)

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,9 @@
-import SourcedEntity from './entity'
-import Entity from './entityProxy'
-import Value from './value'
-
-const SourcedValue = Value
+import { Entity } from './entity'
+import { Value } from './value'
+import { EntityProxy } from './entityProxy'
 
 export {
-  SourcedEntity,
-  SourcedValue,
   Entity,
-  Value
+  Value,
+  EntityProxy
 }

--- a/src/value.js
+++ b/src/value.js
@@ -1,3 +1,3 @@
-export default (obj) => {
+export const Value = (obj) => {
   return Object.freeze(obj)
 }


### PR DESCRIPTION
BREAKING CHANGE: Now uses EventEmitter3 for events in order to work in browsers, and name changes of exports. `SourcedEntity` is now `Entity` and a named export instead of a default export. `SourcedValue` was removed. `Value` is now a named export. `Entity` is now `EntityProxy`. Removed dependency on `util` to work in the browser.

Signed-off-by: Patrick Lee Scott <pat@patscott.io>